### PR TITLE
Importing design system

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,7 +43,7 @@
         "build": {
           "options": {
             "tsConfig": "tsconfig.json",
-            "styles": [],
+            "styles": ["node_modules/design-system/main.css"],
             "scripts": []
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12820,6 +12820,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "design-system": {
+      "version": "git+ssh://git@github.com/victorlbitten/design-system.git#eedb066c8de008f23394ae0b466ebab3273083db",
+      "from": "git+ssh://git@github.com/victorlbitten/design-system.git"
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "~12.2.0",
     "@angular/platform-browser-dynamic": "~12.2.0",
     "@angular/router": "~12.2.0",
+    "design-system": "git+ssh://git@github.com/victorlbitten/design-system.git",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
       "shared-components": [
         "dist/shared-components/shared-components",
         "dist/shared-components"
+      ],
+      "design-system": [
+        "node_modules/design-system"
       ]
     },
     "target": "es2017",


### PR DESCRIPTION
Design system adicionado às dependências da lib.
É necessário fazer o import `import "design-system/main.css" em todos os componentes para utilizar as variáveis e layouts ali definidos; esse passo é necessário pois libs Angular não suportam estilos globais.